### PR TITLE
Updated to Magento rc 2.0.0 + fixed caching problem

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Google_TagManager',
+    __DIR__
+);

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -11,7 +11,7 @@
     <body>
         <referenceContainer name="after.body.start">
             <block class="Google\TagManager\Block\DataLayer" name="gtm_data_layer" as="gtm_data_layer" template="data_layer.phtml"/>
-            <block class="Google\TagManager\Block\Gtm" name="gtm_snippet" as="gtm_snippet" template="gtm.phtml"/>
+            <block class="Google\TagManager\Block\Gtm" name="gtm_snippet" as="gtm_snippet" template="gtm.phtml" cacheable="false" />
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
I added the registration file that is now required for modules in the Magento release candidate.

I also modified the cache setting. As new users haven't accepted the cookie restriction yet (to allow cookies), the full page cache is initially built without the Google Tag Manager, thus not rendering it once cookies are accepted. I disabled the cache for the Google Tag Manager snippet, ensuring the code will be rendered when the user accepts the use of cookies.
